### PR TITLE
Fixed a bug in the input filter

### DIFF
--- a/src/Roave/EmailTemplates/InputFilter/TemplateInputFilter.php
+++ b/src/Roave/EmailTemplates/InputFilter/TemplateInputFilter.php
@@ -43,13 +43,22 @@ namespace Roave\EmailTemplates\InputFilter;
 use Zend\Filter\Boolean;
 use Zend\Filter\StringTrim;
 use Zend\InputFilter\InputFilter;
+use Zend\Validator\NotEmpty;
 
 class TemplateInputFilter extends InputFilter
 {
     public function init()
     {
         $this->add([
-            'name'    => 'updateParameters',
+            'name'       => 'updateParameters',
+            'validators' => [
+                [
+                    'name'    => NotEmpty::class,
+                    'options' => [
+                        'type' => NotEmpty::ALL & ~NotEmpty::BOOLEAN
+                    ]
+                ]
+            ],
             'filters' => [
                 [
                     'name' => Boolean::class


### PR DESCRIPTION
A boolean false value would cause the NotEmpty validator to fail
validation.
