### PR TITLE
Wrong Content-type

### DIFF
--- a/src/Roave/EmailTemplates/Service/EmailService.php
+++ b/src/Roave/EmailTemplates/Service/EmailService.php
@@ -108,9 +108,6 @@ class EmailService implements EmailServiceInterface
 
         list ($subject, $html, $text) = $this->templates->render($templateId, $locale, $params);
 
-        $message = new MailMessage();
-        $message->getHeaders()->addHeaderLine('Content-Type', 'multipart/alternative');
-
         $htmlPart = new MimePart($html);
         $htmlPart->type = 'text/html';
 
@@ -120,6 +117,7 @@ class EmailService implements EmailServiceInterface
         $body = new MimeMessage();
         $body->setParts([$htmlPart, $textPart]);
 
+        $message = new MailMessage();
         $message->setEncoding($this->options->getEncoding());
         $message->setBody($body);
 
@@ -128,6 +126,7 @@ class EmailService implements EmailServiceInterface
         $message->setFrom($this->options->getFrom());
         $message->setTo($email);
         $message->setBcc($this->options->getBcc());
+        $message->getHeaders()->get('content-type')->setType('multipart/alternative');
 
         $this->getTransport()->send($message);
     }

--- a/test/EmailTemplatesTest/Service/EmailServiceTest.php
+++ b/test/EmailTemplatesTest/Service/EmailServiceTest.php
@@ -94,4 +94,30 @@ class EmailServiceTest extends PHPUnit_Framework_TestCase
         $this->service->setTransport($transport);
         $this->service->send($email, $templateId, $parameters, $locale);
     }
+
+    /**
+     * @covers ::send
+     */
+    public function testSendHasCorrectContentType()
+    {
+        $email      = 'contact@roave.com';
+        $locale     = 'sv_SE';
+        $templateId = 'roave:contact';
+        $parameters = ['name' => 'Hotas'];
+
+        $transport = $this->getMock(TransportInterface::class);
+        $transport
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->isInstanceOf(Message::class))
+            ->will($this->returnCallback(function(Message $message) {
+                $contentType = $message->getHeaders()->get('content-type');
+                $this->assertContains('multipart/alternative', $contentType->getFieldValue());
+            }));
+
+        $this->service->setTransport($transport);
+        $this->service->send($email, $templateId, $parameters, $locale);
+    }
+
+
 }


### PR DESCRIPTION
in EmailService::send we set content-type to multipart/alternative but it was overridden when $message->setBody() was called!