### PR TITLE
Override Reply-to

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",
-    "squizlabs/php_codesniffer": "~1.5.2",
+    "squizlabs/php_codesniffer": "~3.2.3",
     "satooshi/php-coveralls": "~0.6",
     "twig/twig": "~1.15.0",
     "doctrine/doctrine-module": "~0.9"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "phpunit/phpunit": "~5.0",
     "squizlabs/php_codesniffer": "~1.5.2",
     "satooshi/php-coveralls": "~0.6",
-    "twig/twig": "~1.15.0"
+    "twig/twig": "~1.15.0",
+    "doctrine/doctrine-module": "~0.9"
   },
   "suggests": {
     "twig/twig": "~1.15.0"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
       "email": "antoine.hedgecock@gmail.com"
     },
     {
-      "name": "Jonas Eriksson"
+      "name": "Jonas Eriksson",
+      "email": "jonaseriksson11@gmail.com"
     }
   ],
   "require": {

--- a/src/Roave/EmailTemplates/Factory/Validator/CanRenderValidatorFactory.php
+++ b/src/Roave/EmailTemplates/Factory/Validator/CanRenderValidatorFactory.php
@@ -2,7 +2,6 @@
 /**
  * @copyright Interactive Solutions
  */
-
 declare(strict_types=1);
 
 namespace Roave\EmailTemplates\Factory\Validator;

--- a/src/Roave/EmailTemplates/Service/EmailService.php
+++ b/src/Roave/EmailTemplates/Service/EmailService.php
@@ -101,10 +101,11 @@ class EmailService implements EmailServiceInterface
         return $this->transport;
     }
 
-    public function send($email, $templateId, $params = [], $locale = null)
+    public function send($email, $templateId, $params = [], $locale = null, $replyTo = null)
     {
         $params = ArrayUtils::iteratorToArray($params);
         $locale = $locale ?: $this->options->getDefaultLocale();
+        $replyTo = $replyTo ?: $this->options->getReplyTo();
 
         list ($subject, $html, $text) = $this->templates->render($templateId, $locale, $params);
 
@@ -122,7 +123,7 @@ class EmailService implements EmailServiceInterface
         $message->setBody($body);
 
         $message->setSubject($subject);
-        $message->setReplyTo($this->options->getReplyTo());
+        $message->setReplyTo($replyTo);
         $message->setFrom($this->options->getFrom());
         $message->setTo($email);
         $message->setBcc($this->options->getBcc());

--- a/src/Roave/EmailTemplates/Service/EmailService.php
+++ b/src/Roave/EmailTemplates/Service/EmailService.php
@@ -93,7 +93,6 @@ class EmailService implements EmailServiceInterface
     public function getTransport()
     {
         if ($this->transport === null) {
-
             $className = $this->options->getDefaultTransport();
             $this->transport = new $className;
         }

--- a/src/Roave/EmailTemplates/Service/EmailServiceInterface.php
+++ b/src/Roave/EmailTemplates/Service/EmailServiceInterface.php
@@ -49,8 +49,9 @@ interface EmailServiceInterface
      * @param string             $templateId The template id to use.
      * @param array|\Traversable $params     A list of traversable parameters.
      * @param null               $locale     Which locale to send the email in.
+     * @param null               $replyTo    Override reply-to header
      *
      * @return void
      */
-    public function send($email, $templateId, $params = [], $locale = null);
+    public function send($email, $templateId, $params = [], $locale = null, $replyTo = null);
 }

--- a/src/Roave/EmailTemplates/Validator/CanRenderValidator.php
+++ b/src/Roave/EmailTemplates/Validator/CanRenderValidator.php
@@ -2,7 +2,6 @@
 /**
  * @copyright Interactive Solutions
  */
-
 declare(strict_types=1);
 
 namespace Roave\EmailTemplates\Validator;
@@ -38,7 +37,6 @@ final class CanRenderValidator extends AbstractValidator
         try {
             $this->engine->render($value, $context['parameters'] ?? []);
         } catch (\Throwable $e) {
-
             $this->error(self::RENDERING_FAILED, $e->getMessage());
 
             return false;

--- a/test/EmailTemplatesTest/InputFilter/TemplateInputFilterTest.php
+++ b/test/EmailTemplatesTest/InputFilter/TemplateInputFilterTest.php
@@ -43,6 +43,8 @@ namespace EmailTemplatesTest\InputFilter;
 
 use PHPUnit_Framework_TestCase;
 use Roave\EmailTemplates\InputFilter\TemplateInputFilter;
+use Roave\EmailTemplates\Service\Template\Engine\EngineInterface;
+use Roave\EmailTemplates\Validator\CanRenderValidator;
 use Zend\Validator\NotEmpty;
 
 /**
@@ -65,7 +67,15 @@ class TemplateInputFilterTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        $canRenderValidator = new CanRenderValidator($this->createMock(EngineInterface::class));
         $this->inputFilter = new TemplateInputFilter();
+
+        $this->inputFilter
+            ->getFactory()
+            ->getDefaultValidatorChain()
+            ->getPluginManager()
+            ->setService(CanRenderValidator::class, $canRenderValidator);
+
         $this->inputFilter->init();
     }
 


### PR DESCRIPTION
In some cases, We want to be able to set a customized Reply-to header and override the one set in options, I also fixed the tests that were failing because of a added Custom validator, I did not readd the needed doctrine entry in composer.json because I dont know why it was removed in the first place, ping @macnibblet 